### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rustycog"
 version = "0.2.1"
 edition = "2024"
 description = "A synchronous task manager"
-repository = "https://www.github.com/Huggepugge1/RustyCog"
+repository = "https://github.com/Huggepugge1/RustyCog"
 license-file = "LICENSE"
 
 [dependencies]


### PR DESCRIPTION
GitHub redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96
